### PR TITLE
#67566496 fix react-router-django conflict

### DIFF
--- a/puzzled_ui/urls.py
+++ b/puzzled_ui/urls.py
@@ -1,6 +1,8 @@
-from django.urls import path
+from django.urls import path, re_path
+from django.views.generic.base import TemplateView
 from . import views
 
 urlpatterns  = [
-    path('', views.index)
+    path('', views.index),
+    re_path(r'^(?:.*)/?$',    TemplateView.as_view(template_name="index.html"))
 ]


### PR DESCRIPTION
  **What does this PR do?**
* Resolve react-routing and django routing conflict

**Description of Task to be completed?**
* Resolve react-routing and django routing conflict

**How should this be manually tested?**
* Pull and checkout to this branch locally by running `git fetch origin ch-fix-react-routing-167566496 && ch-fix-react-routing-167566496`
* Start  the virtual environment `pipenv shell`
* install python requirements `pipenv install`
* install node requirements `npm install`
* migrate the database `python manage.py migrate`
* run builds `npm run build`
* start the django server `python manage.py runserver`
* Hit the endpoint `http://127.0.0.1:8000/sudoku`. This should be successful.

**Any background context you want to provide?**
* N/A

**What are the relevant pivotal tracker stories?**
* [67566496](https://www.pivotaltracker.com/story/show/67566496)
