### PR TITLE
#167567379 fix graphQL bug

### DIFF
--- a/puzzled_api/urls.py
+++ b/puzzled_api/urls.py
@@ -21,6 +21,7 @@ from .schema import schema
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', include('puzzled_ui.urls')),
     path('graphql/', csrf_exempt(GraphQLView.as_view(graphiql=True, schema=schema))),
+    path('', include('puzzled_ui.urls')),
+
 ]


### PR DESCRIPTION
  **What does this PR do?**
* Fix graphql url not found bug

**Description of Task to be completed?**
* Fix graphQL URL not found bug

**How should this be manually tested?**
* Pull and checkout to this branch locally by running `git fetch origin bg-fix-graphql-routing-167567379 && bg-fix-graphql-routing-167567379`
* Start  the virtual environment `pipenv shell`
* install python requirements `pipenv install`
* install node requirements `npm install`
* migrate the database `python manage.py migrate`
* run builds `npm run build`
* start the django server `python manage.py runserver`
* Hit the endpoint `http://127.0.0.1:8000/graphql/`. This should be successful.

**Any background context you want to provide?**
* N/A

**What are the relevant pivotal tracker stories?**
* [167567379](https://www.pivotaltracker.com/story/show/167567379)
